### PR TITLE
docs: remove autocomplete documentation as it is not working

### DIFF
--- a/documentation/guides-cli.asciidoc
+++ b/documentation/guides-cli.asciidoc
@@ -637,31 +637,3 @@ Clears all data stored in query runner cache.
 | --config, -f          | Name of the file with connection configuration.
 | --version, -v         | Shows number version
 |========
-
-== Command autocompletion
-
-In order to enable the command autocompletion, you need to add the following code to your .bashrc or .zshrc:
-
-[source,bash]
-----
-_yargs_completions()
-{
-  local cur_word args type_list
-
-  cur_word="${COMP_WORDS[COMP_CWORD]}"
-  args=("${COMP_WORDS[@]}")
-
-  # ask yargs to generate completions.
-  type_list=$(devon4node --get-yargs-completions "${args[@]}")
-
-  COMPREPLY=( $(compgen -W "${type_list}" -- ${cur_word}) )
-
-  # if no match was found, fall back to filename completion
-  if [ ${#COMPREPLY[@]} -eq 0 ]; then
-    COMPREPLY=()
-  fi
-
-  return 0
-}
-complete -o default -F _yargs_completions devon4node
-----

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,16 +1992,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.27.0":
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz#801a952c10b58e486c9a0b36cf21e2aab1e9e01a"
-  integrity sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.27.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
 "@typescript-eslint/experimental-utils@2.28.0":
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.28.0.tgz#1fd0961cd8ef6522687b4c562647da6e71f8833d"
@@ -2021,19 +2011,6 @@
     "@typescript-eslint/experimental-utils" "2.28.0"
     "@typescript-eslint/typescript-estree" "2.28.0"
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.27.0":
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz#a288e54605412da8b81f1660b56c8b2e42966ce8"
-  integrity sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.28.0":
   version "2.28.0"


### PR DESCRIPTION
Remove autocomplete documentation at guides-cli. The actual implementation is not working well

#31