### PR TITLE
docs: update the coding conventions guide

### DIFF
--- a/documentation/guides-coding-conventions.asciidoc
+++ b/documentation/guides-coding-conventions.asciidoc
@@ -21,7 +21,7 @@ devon4node defines some coding conventions in order to improve the readability, 
 
 In order to ensure that you are following the devon4node coding conventions, you can use the following tools:
 
-- `TSLint`: link:https://palantir.github.io/tslint/[TSLint] is an extensible static analysis tool that checks TypeScript code for readability, maintainability, and functionality errors. We recommend to use the TSLint VSCode extension (included in the devonfw Platform Extension Pack) in order to be able to see the linting error while you are developing.
+- `ESLint`: link:https://eslint.org/[ESLint] ESLint is a tool for identifying and reporting on patterns found in ECMAScript/JavaScript code, with the goal of making code more consistent and avoiding bugs. We recommend to use the link:https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint[ESLint VSCode extension] (included in the devonfw Platform Extension Pack) in order to be able to see the linting errors while you are developing.
 - `Prettier`: link:https://prettier.io/[Prettier] is a code formatter. We recommend to use the Prettier VSCode extension (included in the devonfw Platform Extension Pack) and enable the `editor.formatOnSave` option.
 - `devon4node CLI`: this tool will generate code follwing the devon4node coding conventions. Also, when you generate a new project using the devon4node CLI, it generates the configuration files for TSLint and Prettier that satisfy the devon4node coding conventions.
 
@@ -148,3 +148,14 @@ if (condition) {
   return true;
 }
 ----
+
+== Pre-commit hooks
+
+In order to ensure that your new code follows the coding conventions, devon4node uses by default husky. Husky is a tool that allows you to configure git hooks easly in your project. When you make a `git commit` in your devon4node project, it will execute two actions:
+
+* Prettify the staged files
+* Execute the linter in the staged files
+
+If any action fails, you won't be able to commit your new changes.
+
+NOTE: If you want to skip the git hooks, you can do a commit passing the `--no-verify` flag.


### PR DESCRIPTION
Update the coding conventions guide. Moved from TSLint to ESLint. Also, provide a short description
about husky.

fix #32